### PR TITLE
Added ability to overload settings with config file

### DIFF
--- a/services/Boost_ConfigService.php
+++ b/services/Boost_ConfigService.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright 2018 Imarc LLC
+ * @author Jeff Turcotte [jt] <jeff@imarc.com>
+ * @license Apache (see LICENSE file)
+ */
+
+namespace Craft;
+
+/**
+ * Boost_ConfigServer is a Craft plugin config convenience wrapper that
+ * can merge db-based 'settings' with craft/config-based 'config' files
+ *
+ * Anything found in a config file will overload the settings
+ */
+class Boost_ConfigService extends BaseApplicationComponent
+{
+    public function __get($key)
+    {
+        if (craft()->config->get($key, 'boost') !== null) {
+            return craft()->config->get($key, 'boost');
+        }
+
+        return craft()->plugins->getPlugin('boost')->getSettings()->__get($key);
+    }
+}

--- a/services/Boost_DeploymentService.php
+++ b/services/Boost_DeploymentService.php
@@ -57,7 +57,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
 
     static private function getEnvSettings($env)
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         switch ($env) {
             case 'prod':
@@ -123,7 +123,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
      */
     public function deploy($env, $copyDatabase = true, $branch = 'master')
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         $src_cfg = static::getEnvSettings($cfg->canonicalEnv);
         $new_cfg = static::getEnvSettings($env);
@@ -306,7 +306,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
      */
     public function getCommit($env)
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         if ($env == 'cache') {
 
@@ -340,7 +340,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
      */
     public function prepVCSCache($commit)
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         if (!file_exists($cfg->vcsCache)) {
             $this->sh("mkdir %s", $cfg->vcsCache);
@@ -369,7 +369,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
      */
     public function showLog($env, $branch)
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         $current_commit = $this->getCommit($env);
 
@@ -391,7 +391,7 @@ class Boost_DeploymentService extends BaseApplicationComponent
      */
     public function showVersions()
     {
-        $cfg = craft()->plugins->getPlugin('boost')->getSettings();
+        $cfg = craft()->boost_config;
 
         foreach (glob($cfg->envRoot . "/*", GLOB_ONLYDIR) as $env) {
             $commit = $this->getCommit($env);

--- a/templates/settings.twig
+++ b/templates/settings.twig
@@ -48,8 +48,11 @@
         or contact <a href="https://www.imarc.com">Imarc</a> for more information.
     </p>
 
-    <div class="textline"></div>
+    <p>
+        All settings can be overloaded with a craft/config/boost.php config file.
+    </p>
 
+    <div class="textline"></div>
 </div>
 
 


### PR DESCRIPTION
Need this to overcome an Armor-specific hosting thing, but we've wanted this in there anyway.

Any items placed in craft/config/boost.php will overload the settings in the db.